### PR TITLE
Fix broken About dialog

### DIFF
--- a/SkyEditor.UI/Controllers/Main/MainWindow.cs
+++ b/SkyEditor.UI/Controllers/Main/MainWindow.cs
@@ -625,6 +625,7 @@ namespace SkyEditorUI.Controllers
         private void OnOpenAboutDialogClicked(object sender, EventArgs args)
         {
             aboutDialog!.Run();
+            aboutDialog!.Hide();
         }
 
         private void OnMainItemListButtonPressed(object sender, ButtonPressEventArgs args)


### PR DESCRIPTION
It seems that by default, about dialogs are destroyed once they've been closed. As a result, whenever they're called up again, they can't be shown because the object no longer exists. The fix is to hide the about dialog when it's closed instead.

Inspired by this [Stack Overflow answer](https://stackoverflow.com/a/12896292).

Fixes #55.